### PR TITLE
[YURI-2821] Helper copyToClipboard e componente CopyableButton refatorados

### DIFF
--- a/src/components/inputs/CopyableButton.tsx
+++ b/src/components/inputs/CopyableButton.tsx
@@ -12,13 +12,20 @@ export type Props = {
   text: string
   /** @default 'Copiar' */
   tooltip?: string
+  format?: 'text/plain' | 'text/html'
+  icon?: React.ReactElement
 }
 
-const CopyableButton: React.FC<Props> = ({ text, tooltip = 'Copiar' }) => {
+const CopyableButton: React.FC<Props> = ({
+  text,
+  tooltip = 'Copiar',
+  format = 'text/plain',
+  icon = <FileCopyIcon />
+}) => {
   const [copied, setCopied] = useState(false)
 
   const copyText = () => {
-    copyToClipboard(text)
+    copyToClipboard(text, format)
     setCopied(true)
     setTimeout(() => setCopied(false), 1000)
   }
@@ -26,7 +33,7 @@ const CopyableButton: React.FC<Props> = ({ text, tooltip = 'Copiar' }) => {
   return (
     <Tooltip title={tooltip}>
       <IconButton onClick={copyText}>
-        {copied ? <CheckCircleOutlineIcon /> : <FileCopyIcon />}
+        {copied ? <CheckCircleOutlineIcon /> : icon}
       </IconButton>
     </Tooltip>
   )

--- a/src/helpers/text.ts
+++ b/src/helpers/text.ts
@@ -1,6 +1,48 @@
 /**
+ * https://github.com/sudodoki/copy-to-clipboard/blob/02033decb3affef184672221904d2961f4efc5d9/LICENSE
  * Just copies text passed to clipboard
  */
-export const copyToClipboard = (text: string): void => {
-  navigator.clipboard.writeText(text)
+export const copyToClipboard = (
+  text: string,
+  format: 'text/html' | 'text/plain' = 'text/plain',
+  onError?: () => void,
+  onSuccess?: () => void
+): void => {
+  const range = document.createRange()
+  const selection = document.getSelection()
+
+  const mark = document.createElement('span')
+  mark.textContent = text
+  // reset user styles for span element
+  mark.style.all = 'unset'
+  // prevents scrolling to the end of the page
+  mark.style.position = 'fixed'
+  mark.style.top = '0'
+  // used to preserve spaces and line breaks
+  mark.style.whiteSpace = 'pre'
+  // do not inherit user-select (it may be `none`)
+  mark.style.userSelect = 'text'
+
+  mark.addEventListener('copy', (e) => {
+    e.stopPropagation()
+    if (format === 'text/html') {
+      e.preventDefault()
+      e.clipboardData?.clearData()
+      e.clipboardData?.setData(format, text)
+    }
+  })
+  document.body.appendChild(mark)
+
+  range.selectNodeContents(mark)
+  selection?.addRange(range)
+
+  document.execCommand('copy')
+  const successful = document.execCommand('copy')
+  if (successful) {
+    onSuccess?.()
+  } else {
+    onError?.()
+  }
+
+  document.body.removeChild(mark)
 }

--- a/src/stories/inputs/CopyableButton.stories.tsx
+++ b/src/stories/inputs/CopyableButton.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { ComponentMeta, ComponentStory, Story } from '@storybook/react'
 
+import { Email as EmailIcon } from '@mui/icons-material'
 import { Card, CardContent } from '@mui/material'
 
 import CopyableButton, { Props } from '../../components/inputs/CopyableButton'
@@ -24,4 +25,17 @@ const Template: ComponentStory<typeof CopyableButton> = (args) => {
 export const Example: Story<Props> = Template.bind({})
 Example.args = {
   text: 'Some text to copy'
+}
+
+export const WithCustomIcon: Story<Props> = Template.bind({})
+WithCustomIcon.args = {
+  text: 'Some text to copy',
+  icon: <EmailIcon />
+}
+
+export const WithCustomFormat: Story<Props> = Template.bind({})
+WithCustomFormat.args = {
+  text: '<b>Some text to copy</b>',
+  icon: <EmailIcon />,
+  format: 'text/html'
 }

--- a/src/stories/inputs/CopyableButton.stories.tsx
+++ b/src/stories/inputs/CopyableButton.stories.tsx
@@ -35,7 +35,13 @@ WithCustomIcon.args = {
 
 export const WithCustomFormat: Story<Props> = Template.bind({})
 WithCustomFormat.args = {
-  text: '<b>Some text to copy</b>',
+  text: `
+  <div>
+    some <strong>text</strong> <p style="color: blue">in blue</p>
+
+    and some text <p style="text-decoration: underline">underlined</p>
+  </div>
+  `,
   icon: <EmailIcon />,
   format: 'text/html'
 }


### PR DESCRIPTION
### Tipo de Pull Request

- [ ] Bug fix
- [X] Nova feature
- [X] Documentação
- [ ] Release
- [ ] CI/CD
- [ ] UI/UX

### Esse Pull Request realiza a seguinte alteração:

- Possibilidade de alterar icone do CopyableButton
- copyToClipboard para formato 'text/html'

---

### Screenshots (para mudanças visuais):

---

- [ ] Esse PR precisa de tasks scheduled/executadas pós-deploy
