### PR TITLE
[YURI-2901] Adicionar prop opcional 'allowEmptyValues' para EChartsFunnelGraph, pra permitir valores nulos no gráfico

### DIFF
--- a/src/components/graphs/EChartsFunnelGraph.tsx
+++ b/src/components/graphs/EChartsFunnelGraph.tsx
@@ -59,6 +59,11 @@ export type Props = {
    * Customization for graph legends (ex.: positioning, font styling, etc.)
    */
   legendOptions?: Partial<EChartOption.Legend>
+  /**
+   * If true, allow values passed as '0' to be displayed in the graph.
+   * @default false
+   */
+  allowEmptyValues?: boolean
 } & Partial<EChartsReactProps>
 
 function formatParamIsSingle(
@@ -74,12 +79,18 @@ const EChartsFunnelGraph: React.FC<Props> = ({
   seriesOptions,
   legendOptions,
   withLegends = false,
+  allowEmptyValues = false,
   ...echartProps
 }) => {
-  const mappedData = useMemo(
-    () => data.filter((d) => d.value).map((d) => ({ ...d, name: d.label })),
-    [data]
-  )
+  const mappedData = useMemo(() => {
+    let filteredData = data
+
+    if (!allowEmptyValues) {
+      filteredData = data.filter((d) => d.value)
+    }
+
+    return filteredData.map((d) => ({ ...d, name: d.label }))
+  }, [data])
 
   const smoothedData = useMemo(
     () =>

--- a/src/stories/graphs/EChartsFunnelGraph.stories.tsx
+++ b/src/stories/graphs/EChartsFunnelGraph.stories.tsx
@@ -105,3 +105,18 @@ CustomLegend.args = {
   },
   withLegends: true
 }
+
+export const WithEmptyValues: Story<Props> = Template.bind({})
+WithEmptyValues.args = {
+  data: [...exampleData, { id: 'empty', label: 'Empty', value: 0 }],
+  colors: [
+    ...Array(exampleData.length / 2).fill('#26bd60'),
+    ...Array(exampleData.length / 2).fill('#c4ba2f')
+  ],
+  seriesOptions: {
+    top: '40',
+    height: '85%'
+  },
+  allowEmptyValues: true,
+  withLegends: true
+}


### PR DESCRIPTION
### Tasks

- [x] Preenchi o Assignee do Pull Request
- [x] Preenchi o(s) Reviewer(s) do Pull Request
- [x] Realizei self-review do meu Pull Request localmente e pelo GitHub
- [x] Preenchi a(s) label(s) do Pull Request
  > Ex.: `enhancement` / `bug` / `CI/CD`. Utilize a label `WIP` para Pull Requests incompletos
  
> Evite Pull Requests com múltiplos objetivos (criar uma feature e corrigir um bug no mesmo Pull Request por exemplo)


### Esse Pull Request realiza a seguinte alteração:

---

### Screenshots (para mudanças visuais):

![image](https://user-images.githubusercontent.com/37747572/165621923-1db079c7-fc4f-4eec-837a-53ba44b5f4bf.png)

---

- Esse PR precisa de tasks scheduled/executadas pós-deploy:
  - *Listar tasks aqui, com uma breve descrição, caso existam*
