### PR TITLE
Corrigido prop `label` do componente `StatusChip` aceitando apenas `string` e não elementos React

### DIFF
--- a/src/components/chips/StatusChip.tsx
+++ b/src/components/chips/StatusChip.tsx
@@ -3,18 +3,16 @@ import React, { useMemo } from 'react'
 import { Property } from 'csstype'
 
 import { Chip, ChipProps, Theme, Tooltip } from '@mui/material'
-import { ResponsiveStyleValue, SxProps, SystemStyleObject } from '@mui/system'
+import { ResponsiveStyleValue, SystemStyleObject } from '@mui/system'
 
 export type Props<Status extends string = string> = {
   value: Status
-  label?: string
   errorValues?: Status[]
   successValues?: Status[]
   warningValues?: Status[]
   primaryValues?: Status[]
   /** Optional tooltip on chip hover */
   tooltip?: string
-  sx?: SxProps<Theme>
 } & ChipProps
 
 const StatusChip = <Status extends string = string>({

--- a/src/stories/chips/StatusChip.stories.tsx
+++ b/src/stories/chips/StatusChip.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { ComponentMeta, ComponentStory, Story } from '@storybook/react'
 
-import { Card, CardContent, Grid } from '@mui/material'
+import { Card, CardContent, Grid, Typography } from '@mui/material'
 
 import { Props } from '../../components/chips/StatusChip'
 import { StatusChip } from '../../index'
@@ -29,23 +29,48 @@ const Template: ComponentStory<typeof StatusChip> = (args) => {
       <CardContent>
         <Grid container spacing={2}>
           <Grid item>
-            <StatusChip {...args} value={canceled} label='Canceled' />
+            <StatusChip
+              {...args}
+              value={canceled}
+              label={args.label || 'Canceled'}
+              onDelete={undefined}
+            />
           </Grid>
 
           <Grid item>
-            <StatusChip {...args} value={open} label='Open' />
+            <StatusChip
+              {...args}
+              value={open}
+              label={args.label || 'Open'}
+              onDelete={undefined}
+            />
           </Grid>
 
           <Grid item>
-            <StatusChip {...args} value={onHold} label='On Hold' />
+            <StatusChip
+              {...args}
+              value={onHold}
+              label={args.label || 'On Hold'}
+              onDelete={undefined}
+            />
           </Grid>
 
           <Grid item>
-            <StatusChip {...args} value={inactive} label='Inactive' />
+            <StatusChip
+              {...args}
+              value={inactive}
+              label={args.label || 'Inactive'}
+              onDelete={undefined}
+            />
           </Grid>
 
           <Grid item>
-            <StatusChip {...args} value={active} label='Active' />
+            <StatusChip
+              {...args}
+              value={active}
+              label={args.label || 'Active'}
+              onDelete={undefined}
+            />
           </Grid>
         </Grid>
       </CardContent>
@@ -58,6 +83,14 @@ Example.args = {
   successValues: ['open', 'active'],
   errorValues: ['canceled', 'inactive'],
   warningValues: ['on_hold']
+}
+
+export const CustomLabel: Story<Props> = Template.bind({})
+CustomLabel.args = {
+  successValues: ['open', 'active'],
+  errorValues: ['canceled', 'inactive'],
+  warningValues: ['on_hold'],
+  label: <Typography variant='subtitle1'>Some label</Typography>
 }
 
 export const WithTooltip: Story<Props> = Template.bind({})


### PR DESCRIPTION
### Tasks

- [x] Preenchi o Assignee do Pull Request
- [x] Preenchi o(s) Reviewer(s) do Pull Request
- [x] Realizei self-review do meu Pull Request localmente e pelo GitHub
- [x] Preenchi a(s) label(s) do Pull Request
  > Ex.: `enhancement` / `bug` / `CI/CD`. Utilize a label `WIP` para Pull Requests incompletos
  
> Evite Pull Requests com múltiplos objetivos (criar uma feature e corrigir um bug no mesmo Pull Request por exemplo)


### Esse Pull Request realiza a seguinte alteração:

---

### Screenshots (para mudanças visuais):

---

- Esse PR precisa de tasks scheduled/executadas pós-deploy:
  - *Listar tasks aqui, com uma breve descrição, caso existam*
