### PR TITLE
[YURI2-456] - Adicionar GitHub PAT em checkout de novos releases para permitir pular branch protection rules

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -26,9 +26,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+        with:
+          token: ${{ secrets.GH_SECRET_PAT }}
 
       - name: Cache Yarn Dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
### Tasks

- [x] Preenchi o Assignee do Pull Request
- [x] Preenchi o(s) Reviewer(s) do Pull Request (em branco caso não tenha um específico)
- [x] Realizei self-review do meu Pull Request localmente e pelo GitHub
- [x] Preenchi a(s) label(s) do Pull Request
  > Ex.: `enhancement` / `bug` / `CI/CD`
  
> Evite Pull Requests com múltiplos objetivos (criar uma feature e corrigir um bug no mesmo Pull Request por exemplo)


### Esse Pull Request realiza a seguinte alteração:

Adiciona GitHub PAT para pular branch protection rules que obrigam um PR aprovado para dar merge, para que as actions do GitHub consigam dar push diretamente para staging/master em deploys

---

- Esse PR precisa de tasks scheduled/executadas pós-deploy:
  - *Listar tasks aqui, com uma breve descrição, caso existam*
