### PR TITLE
Correções e melhorias para o componente de notificação

### DIFF
--- a/src/components/NavBar/YuMobileNavBar.tsx
+++ b/src/components/NavBar/YuMobileNavBar.tsx
@@ -77,7 +77,9 @@ const YuMobileNavBar: React.FC<Props> = ({
                 </IconButton>
               </Typography>
             )}
-            {!!mobileActionItem && <ToolbarButton button={mobileActionItem} />}
+            {!!mobileActionItem && (
+              <Box sx={{ mt: 1 }}>{mobileActionItem.icon}</Box>
+            )}
             <IconButton
               className={classes.logoYuri}
               color='inherit'

--- a/src/components/notifications/NotificationMenu.tsx
+++ b/src/components/notifications/NotificationMenu.tsx
@@ -12,6 +12,7 @@ import {
   Box,
   Button,
   FormControlLabel,
+  IconButton,
   Link,
   Popover,
   Switch,
@@ -20,6 +21,7 @@ import {
   useTheme
 } from '@mui/material'
 import { styled } from '@mui/material/styles'
+import { SxProps, Theme } from '@mui/system'
 
 export interface YuriNotification {
   id: string | number
@@ -51,6 +53,10 @@ export type Props = {
    * @default 'Marcar todas como lidas'
    */
   markAllAsReadText?: string
+  /**
+   * @description Sx props for the container
+   */
+  containerSx?: SxProps<Theme> | undefined
   /**
    * @example {id: 1, title: 'Notificação 1', description: 'Descrição da notificação 1', created_at: new Date(), updated_at: new Date(), viewed_at: new Date(), viewed: false}
    */
@@ -126,10 +132,11 @@ function linkifyText(str?: string): (string | JSX.Element)[] | undefined {
 }
 
 const NotificationPopover: React.FC<Props> = ({
-  title,
-  emptyNotificationText,
-  showOnlyUnreadText,
-  markAllAsReadText,
+  title = 'Notificações',
+  emptyNotificationText = 'Você não tem notificações',
+  showOnlyUnreadText = 'Ver somente não lidas',
+  markAllAsReadText = 'Marcar todas como lidas',
+  containerSx,
   notifications,
   handleNotifications,
   open,
@@ -212,15 +219,18 @@ const NotificationPopover: React.FC<Props> = ({
   }
   return (
     <div>
-      <Badge badgeContent={badgeNotificationsContent} color='primary'>
-        <NotificationsIcon
-          onClick={(e) => {
-            setAnchorElNotify(e.currentTarget)
-            setAnchorEl?.(e.currentTarget)
-          }}
-          id='notify-item'
-        />
-      </Badge>
+      <IconButton
+        onClick={(e) => {
+          setAnchorElNotify(e.currentTarget)
+          setAnchorEl?.(e.currentTarget)
+        }}
+        id='notify-item'
+        color='inherit'
+      >
+        <Badge badgeContent={badgeNotificationsContent} color='primary'>
+          <NotificationsIcon />
+        </Badge>
+      </IconButton>
       <Popover
         anchorEl={anchorElNotify || anchorEl}
         open={open || Boolean(anchorElNotify)}
@@ -249,7 +259,7 @@ const NotificationPopover: React.FC<Props> = ({
           alignContent: 'center'
         }}
       >
-        <Box sx={{ width: isMobile ? '100%' : '45vw' }}>
+        <Box>
           <Typography
             variant='h6'
             component='div'
@@ -264,8 +274,11 @@ const NotificationPopover: React.FC<Props> = ({
               flexDirection: 'column',
               alignContent: 'center',
               alignItems: 'center',
-              maxHeight: '40vh',
-              overflowY: 'auto'
+              overflowY: 'auto',
+              height: '40vh',
+              width: isMobile ? '100%' : '45vw',
+              pb: 2,
+              ...containerSx
             }}
           >
             {!!filteredNotifications && filteredNotifications?.length ? (


### PR DESCRIPTION
### Tasks

- [x] Preenchi o Assignee do Pull Request
- [x] Preenchi o(s) Reviewer(s) do Pull Request (em branco caso não tenha um específico)
- [x] Realizei self-review do meu Pull Request localmente e pelo GitHub
- [x] Criei testes relevantes para o meu código, ou determinei, em discussão com a equipe, que não há necessidade
- [x] Preenchi a(s) label(s) do Pull Request
  > Ex.: `enhancement` / `bug` / `CI/CD`
  
> Evite Pull Requests com múltiplos objetivos (criar uma feature e corrigir um bug no mesmo Pull Request por exemplo)


### Esse Pull Request realiza a seguinte alteração:

---
- Faz com que o container de notificações tenha um Height e Width fixos, assim o tamanho não sendo influenciado por ter novas notificações para renderizar.
- Cria uma props para estilizar o container de notificações.
- Aplica um padding para a ultima notificação da lista quando for expandida não ficar cortada.
- Aplica valores padrão para alguns props.
- Corrige o pequeno bug de que quando clicava no badge não abria o menu de notificações.

### Screenshots (para mudanças visuais):

---
![image](https://user-images.githubusercontent.com/85767287/214144754-7c539db7-bc81-4b6b-a3c2-50ac19fbd552.png)
![image](https://user-images.githubusercontent.com/85767287/214144803-9979a8dd-a526-4945-addb-1a408958f106.png)
![image](https://user-images.githubusercontent.com/85767287/214144882-e7871fc0-09a9-47e8-a980-dda96e0878bf.png)


- Esse PR precisa de tasks scheduled/executadas pós-deploy:
  - *Listar tasks aqui, com uma breve descrição, caso existam*
