### PR TITLE
Adicionado um botao de acao no content da notificacao

### DIFF
--- a/src/components/notifications/NotificationMenu.tsx
+++ b/src/components/notifications/NotificationMenu.tsx
@@ -62,6 +62,12 @@ export type Props = {
    */
   notifications: YuriNotification[]
   /**
+   * @description React element to be used as the action button
+   * @example <Button>Teste</Button>
+   * @default undefined
+   */
+  actionButton?: React.ReactElement
+  /**
    * @description Function to handle notifications
    * @example (ids: (string | number)[]) => void
    */
@@ -138,6 +144,7 @@ const NotificationPopover: React.FC<Props> = ({
   markAllAsReadText = 'Marcar todas como lidas',
   containerSx,
   notifications,
+  actionButton,
   handleNotifications,
   open,
   anchorEl,
@@ -320,12 +327,23 @@ const NotificationPopover: React.FC<Props> = ({
                     </Box>
                   </AccordionSummary>
                   <AccordionDetails>
-                    <Box sx={{ width: '80%' }}>
+                    <Box
+                      sx={{
+                        width: '80%',
+                        display: 'flex',
+                        flexDirection: 'column'
+                      }}
+                    >
                       <Typography
-                        sx={{ color: 'text.secondary', textAlign: 'left' }}
+                        sx={{
+                          color: 'text.secondary',
+                          textAlign: 'left',
+                          mb: 1
+                        }}
                       >
                         {linkifyText(notification.description)}
                       </Typography>
+                      <Box>{actionButton}</Box>
                     </Box>
                   </AccordionDetails>
                 </Accordion>

--- a/src/stories/notifications/NotificationMenu.stories.tsx
+++ b/src/stories/notifications/NotificationMenu.stories.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 
 import { ComponentMeta, ComponentStory, Story } from '@storybook/react'
 
+import { Button } from '@mui/material'
+
 import NotificationMenu, {
   Props
 } from '../../components/notifications/NotificationMenu'
@@ -43,4 +45,14 @@ const baseProps: Partial<Props> = {
 export const Base: Story<Props> = Template.bind({})
 Base.args = {
   ...baseProps
+}
+
+export const WithActionButton: Story<Props> = Template.bind({})
+WithActionButton.args = {
+  ...baseProps,
+  actionButton: (
+    <Button onClick={() => alert('Button Click')} variant='outlined'>
+      teste
+    </Button>
+  )
 }


### PR DESCRIPTION
### Tasks

- [x] Preenchi o Assignee do Pull Request
- [x] Preenchi o(s) Reviewer(s) do Pull Request (em branco caso não tenha um específico)
- [x] Realizei self-review do meu Pull Request localmente e pelo GitHub
- [x] Criei testes relevantes para o meu código, ou determinei, em discussão com a equipe, que não há necessidade
- [x] Preenchi a(s) label(s) do Pull Request
  > Ex.: `enhancement` / `bug` / `CI/CD`
  
> Evite Pull Requests com múltiplos objetivos (criar uma feature e corrigir um bug no mesmo Pull Request por exemplo)


### Esse Pull Request realiza a seguinte alteração:

---
- Cria uma prop para ser um botão de ação, esse botão é renderizado dentro de cada notificação.

### Screenshots (para mudanças visuais):

---
![image](https://user-images.githubusercontent.com/85767287/215493509-c95f90c5-db42-4657-9dbf-7c1b43147460.png)


- Esse PR precisa de tasks scheduled/executadas pós-deploy:
  - *Listar tasks aqui, com uma breve descrição, caso existam*
