### PR TITLE
Corrigir releases sendo feitos sem arquivos de build

### DIFF
--- a/.github/workflows/link_jira.yml
+++ b/.github/workflows/link_jira.yml
@@ -1,11 +1,14 @@
 name: Link Jira issues
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
   change-pr-name:
     name: Change Pull Request name
     runs-on: ubuntu-latest
-    
+    if: "!contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'ignore-jira-link')"
+
     permissions:
       contents: read
       pull-requests: write

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build": "microbundle-crl --no-compress --external=react,react-dom,react-is --format modern,cjs --css-modules false",
     "build:types": "tsc --declaration --emitDeclarationOnly --jsx react --esModuleInterop --outDir dist && cp dist/src/* ./dist -r || exit 0",
+    "prepare": "run-s build",
     "test:build": "run-s build",
     "test:lint": "eslint .",
     "test": "vitest run",


### PR DESCRIPTION
### Tasks

- [x] Preenchi o Assignee do Pull Request
- [x] Preenchi o(s) Reviewer(s) do Pull Request (em branco caso não tenha um específico)
- [x] Realizei self-review do meu Pull Request localmente e pelo GitHub
- [x] Criei testes relevantes para o meu código, ou determinei, em discussão com a equipe, que não há necessidade
- [x] Preenchi a(s) label(s) do Pull Request
  > Ex.: `enhancement` / `bug` / `CI/CD`
  
> Evite Pull Requests com múltiplos objetivos (criar uma feature e corrigir um bug no mesmo Pull Request por exemplo)


### Esse Pull Request realiza a seguinte alteração:

Por algumas mudanças conflitantes realizadas no `package.json`, a etapa de build acabou sendo excluída, o que passou a fazer releases serem feitos sem gerar a pasta de build (`dist`) antes, resultando em releases vazios não-utilizáveis
