### PR TITLE
Corrigir styling de background de DataTable sempre seguindo cor do body

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 YU TECNOLOGIA E CONSULTORIA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ const App = () => {
 
 ## License
 
-UNLICENSED © [jornadayu](https://github.com/jornadayu)
+MIT © [YU Tecnologia e Consultoria](https://github.com/jornadayu/LICENSE)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.2",
   "description": "A collection of React components, helpers and assets used at YU",
   "author": "jornadayu",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jornadayu/yu-open-lib"

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -21,7 +21,8 @@ import {
   TableContainerProps,
   TableHead,
   TableRow,
-  TextFieldProps
+  TextFieldProps,
+  useTheme
 } from '@mui/material'
 
 import DataTableHeader from './DataTableHeader'
@@ -159,6 +160,7 @@ const InnerDataTable = <T extends DataModel>({
   })
 
   const { grouping } = table.getState()
+  const theme = useTheme()
 
   return (
     <TableContainer {...tableContainerProps}>
@@ -184,7 +186,11 @@ const InnerDataTable = <T extends DataModel>({
           <DataTableHeader table={table} />
         </TableHead>
 
-        <TableBody>
+        <TableBody
+          sx={{
+            bgcolor: theme.palette.background.default
+          }}
+        >
           {table.getRowModel().rows.map((row) => (
             <DataTableRow row={row} key={row.id} grouping={grouping} />
           ))}


### PR DESCRIPTION
### Tasks

- [x] Preenchi o Assignee do Pull Request
- [x] Preenchi o(s) Reviewer(s) do Pull Request (em branco caso não tenha um específico)
- [x] Realizei self-review do meu Pull Request localmente e pelo GitHub
- [x] Criei testes relevantes para o meu código, ou determinei, em discussão com a equipe, que não há necessidade
- [x] Preenchi a(s) label(s) do Pull Request
  > Ex.: `enhancement` / `bug` / `CI/CD`
  
> Evite Pull Requests com múltiplos objetivos (criar uma feature e corrigir um bug no mesmo Pull Request por exemplo)


### Esse Pull Request realiza a seguinte alteração:

Background do TableBody de DataTable agora segue seu tema do MUI ao invés de sempre utilizar a cor de background do <body> da página onde ele é utilizado